### PR TITLE
feat: Fixed timestamp plus rsvp things

### DIFF
--- a/src/main/java/org/codeseoul/event_member_management/common/Auditable.java
+++ b/src/main/java/org/codeseoul/event_member_management/common/Auditable.java
@@ -1,5 +1,6 @@
 package org.codeseoul.event_member_management.common;
 
+import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -11,6 +12,7 @@ import java.time.OffsetDateTime;
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
+@Getter
 public abstract class Auditable {
 
     @Column(nullable = false)

--- a/src/main/java/org/codeseoul/event_member_management/event/Event.java
+++ b/src/main/java/org/codeseoul/event_member_management/event/Event.java
@@ -4,10 +4,9 @@ import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.codeseoul.event_member_management.common.Auditable;
 import org.codeseoul.event_member_management.rsvp.Rsvp;
 import org.codeseoul.event_member_management.series.Series;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
 
 import javax.persistence.*;
 import java.sql.Timestamp;
@@ -18,7 +17,7 @@ import java.util.Set;
 @Entity
 @NoArgsConstructor
 @Data
-public class Event {
+public class Event extends Auditable {
     private @Id @GeneratedValue Long id;
     private String title;
     private String description;
@@ -36,14 +35,6 @@ public class Event {
     @JoinColumn(name = "series_id")
     @JsonBackReference
     private Series series;
-
-    @Column(insertable = false, updatable = false)
-    @CreationTimestamp
-    private Timestamp createdAt;
-
-    @Column(insertable = false, updatable = false)
-    @UpdateTimestamp
-    private Timestamp updatedAt;
 
     public Event(String title, String description, Timestamp startTimestamp, Integer durationMinutes, String imageUrl, String venue, String onlineLink, Series series) {
         this.title = title;

--- a/src/main/java/org/codeseoul/event_member_management/member/Member.java
+++ b/src/main/java/org/codeseoul/event_member_management/member/Member.java
@@ -1,50 +1,41 @@
 package org.codeseoul.event_member_management.member;
 
 import com.fasterxml.jackson.annotation.JsonManagedReference;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.codeseoul.event_member_management.common.Auditable;
 import org.codeseoul.event_member_management.rsvp.Rsvp;
 import org.codeseoul.event_member_management.sns_account.SnsAccount;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
 
 import javax.persistence.*;
-import java.sql.Timestamp;
 import java.util.*;
 
 @Entity
 @NoArgsConstructor
 @Data
-@Table(
-        uniqueConstraints = @UniqueConstraint(
-                // TODO: change to snake case
-                columnNames = {"username", "email", "phoneNumber"}
-        )
-)
-public class Member {
+public class Member extends Auditable {
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private @Id
     @GeneratedValue Long id;
+    @Column(unique = true)
     private String username;
     private String displayName;
+    @Column(unique = true)
     private String email;
+    @Column(unique = true)
     private String phoneNumber;
     private String imageUrl;
     private String shortBio;
 
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
     @JsonManagedReference
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private Set<Rsvp> rsvps = new HashSet<>();
 
     @OneToMany(mappedBy = "member", fetch = FetchType.EAGER)
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private List<SnsAccount> snsAccounts = new ArrayList<>();
-
-    @Column(insertable = false, updatable = false)
-    @CreationTimestamp
-    private Timestamp createdAt;
-
-    @Column(insertable = false, updatable = false)
-    @UpdateTimestamp
-    private Timestamp updatedAt;
 
     public Member(String username, String displayName, String email, String phoneNumber, String imageUrl, String shortBio) {
         this.username = username;

--- a/src/main/java/org/codeseoul/event_member_management/rsvp/Rsvp.java
+++ b/src/main/java/org/codeseoul/event_member_management/rsvp/Rsvp.java
@@ -3,22 +3,23 @@ package org.codeseoul.event_member_management.rsvp;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.codeseoul.event_member_management.common.Auditable;
 import org.codeseoul.event_member_management.event.Event;
 import org.codeseoul.event_member_management.member.Member;
 import org.codeseoul.event_member_management.rsvp_state.RsvpState;
-import org.codeseoul.event_member_management.series.Series;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
 
 import javax.persistence.*;
-import java.sql.Timestamp;
 import java.util.Objects;
-import java.util.Set;
 
 @Entity
 @NoArgsConstructor
 @Data
-public class Rsvp {
+@Table(
+        uniqueConstraints = @UniqueConstraint(
+                columnNames = {"event_id", "member_id"}
+        )
+)
+public class Rsvp extends Auditable {
     private @Id @GeneratedValue Long id;
 
     @ManyToOne(optional = false, fetch = FetchType.EAGER)
@@ -34,14 +35,6 @@ public class Rsvp {
     @ManyToOne(optional = false, fetch = FetchType.EAGER)
     @JoinColumn(name = "state_id")
     private RsvpState state;
-
-    @Column(insertable = false, updatable = false)
-    @CreationTimestamp
-    private Timestamp createdAt;
-
-    @Column(insertable = false, updatable = false)
-    @UpdateTimestamp
-    private Timestamp updatedAt;
 
     public Rsvp(Member member, Event event, RsvpState state) {
         this.member = member;

--- a/src/main/java/org/codeseoul/event_member_management/rsvp/RsvpModelAssembler.java
+++ b/src/main/java/org/codeseoul/event_member_management/rsvp/RsvpModelAssembler.java
@@ -11,13 +11,14 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 @Component
-public class RsvpModelAssembler implements RepresentationModelAssembler<Rsvp, EntityModel<Rsvp>> {
+public class RsvpModelAssembler implements RepresentationModelAssembler<Rsvp, EntityModel<RsvpReadSchema>> {
 
     @Override
     @NonNull
-    public EntityModel<Rsvp> toModel(@NonNull Rsvp rsvp) {
+    public EntityModel<RsvpReadSchema> toModel(@NonNull Rsvp rsvp) {
 
-        return EntityModel.of(rsvp,
+        RsvpReadSchema rsvpReadSchema = new RsvpReadSchema(rsvp);
+        return EntityModel.of(rsvpReadSchema,
                 linkTo(methodOn(RsvpController.class).one(rsvp.getId())).withSelfRel(),
                 linkTo(methodOn(MemberController.class).one(rsvp.getMember().getId())).withRel("member"),
                 linkTo(methodOn(EventController.class).one(rsvp.getEvent().getId())).withRel("event"));

--- a/src/main/java/org/codeseoul/event_member_management/rsvp/RsvpReadSchema.java
+++ b/src/main/java/org/codeseoul/event_member_management/rsvp/RsvpReadSchema.java
@@ -1,0 +1,35 @@
+package org.codeseoul.event_member_management.rsvp;
+
+import lombok.Data;
+import lombok.NonNull;
+import org.codeseoul.event_member_management.event.Event;
+import org.codeseoul.event_member_management.member.Member;
+import org.codeseoul.event_member_management.rsvp_state.RsvpState;
+
+import java.time.OffsetDateTime;
+
+@Data
+public class RsvpReadSchema {
+    private Long eventId;
+    private String eventTitle;
+    private Long memberId;
+    private String memberDisplayName;
+    private String rsvpState;
+    private OffsetDateTime createdAt;
+    private OffsetDateTime updatedAt;
+
+    public RsvpReadSchema(@NonNull Rsvp rsvp) {
+        Event event = rsvp.getEvent();
+        Member member = rsvp.getMember();
+        RsvpState rsvpState = rsvp.getState();
+        this.eventId = event.getId();
+        this.eventTitle = event.getTitle();
+        this.memberId = member.getId();
+        this.memberDisplayName = member.getDisplayName();
+        this.rsvpState = rsvpState.getState();
+        this.createdAt = rsvp.getCreatedAt();
+        this.updatedAt = rsvp.getUpdatedAt();
+    }
+}
+
+

--- a/src/main/java/org/codeseoul/event_member_management/rsvp/RsvpStateSchema.java
+++ b/src/main/java/org/codeseoul/event_member_management/rsvp/RsvpStateSchema.java
@@ -1,0 +1,8 @@
+package org.codeseoul.event_member_management.rsvp;
+
+import lombok.Data;
+
+@Data
+public class RsvpStateSchema {
+    private Long stateId;
+}

--- a/src/main/java/org/codeseoul/event_member_management/rsvp_state/RsvpState.java
+++ b/src/main/java/org/codeseoul/event_member_management/rsvp_state/RsvpState.java
@@ -2,11 +2,10 @@ package org.codeseoul.event_member_management.rsvp_state;
 
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
 
-import javax.persistence.*;
-import java.sql.Timestamp;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
 import java.util.Objects;
 
 @Entity
@@ -17,14 +16,6 @@ public class RsvpState {
 
     private String state;
 
-    @Column(insertable = false, updatable = false)
-    @CreationTimestamp
-    private Timestamp createdAt;
-
-    @Column(insertable = false, updatable = false)
-    @UpdateTimestamp
-    private Timestamp updatedAt;
-
     public RsvpState(String state) {
         this.state = state;
     }
@@ -33,10 +24,10 @@ public class RsvpState {
     public boolean equals(Object o) {
         if (this == o)
             return true;
-        if (!(o instanceof RsvpState state))
+        if (!(o instanceof RsvpState rsvpState))
             return false;
-        return Objects.equals(this.id, state.id)
-                && Objects.equals(this.state, state.state);
+        return Objects.equals(this.id, rsvpState.id)
+                && Objects.equals(this.state, rsvpState.state);
     }
 
     @Override

--- a/src/main/java/org/codeseoul/event_member_management/rsvp_state/RsvpStateController.java
+++ b/src/main/java/org/codeseoul/event_member_management/rsvp_state/RsvpStateController.java
@@ -1,0 +1,38 @@
+package org.codeseoul.event_member_management.rsvp_state;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
+
+@RestController
+public class RsvpStateController {
+
+    private static final Logger log = LoggerFactory.getLogger(RsvpStateController.class);
+
+    private final RsvpStateRepository repository;
+    private final RsvpStateModelAssembler assembler;
+
+    RsvpStateController(RsvpStateRepository repository, RsvpStateModelAssembler assembler) {
+        this.repository = repository;
+        this.assembler = assembler;
+    }
+
+    @GetMapping("/rsvpStates")
+    CollectionModel<EntityModel<RsvpState>> all() {
+        List<EntityModel<RsvpState>> rsvpStates = repository.findAll().stream()
+                .map(assembler::toModel)
+                .collect(Collectors.toList());
+
+        return CollectionModel.of(rsvpStates,
+                linkTo(methodOn(RsvpStateController.class).all()).withRel("all"));
+    }
+}

--- a/src/main/java/org/codeseoul/event_member_management/rsvp_state/RsvpStateModelAssembler.java
+++ b/src/main/java/org/codeseoul/event_member_management/rsvp_state/RsvpStateModelAssembler.java
@@ -1,0 +1,21 @@
+package org.codeseoul.event_member_management.rsvp_state;
+
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.server.RepresentationModelAssembler;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
+
+@Component
+public class RsvpStateModelAssembler implements RepresentationModelAssembler<RsvpState, EntityModel<RsvpState>> {
+
+    @Override
+    @NonNull
+    public EntityModel<RsvpState> toModel(@NonNull RsvpState rsvpState) {
+
+        return EntityModel.of(rsvpState,
+                linkTo(methodOn(RsvpStateController.class).all()).withRel("all"));
+    }
+}

--- a/src/main/java/org/codeseoul/event_member_management/rsvp_state/RsvpStateNotFoundAdvice.java
+++ b/src/main/java/org/codeseoul/event_member_management/rsvp_state/RsvpStateNotFoundAdvice.java
@@ -1,0 +1,18 @@
+package org.codeseoul.event_member_management.rsvp_state;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ControllerAdvice
+public class RsvpStateNotFoundAdvice {
+
+    @ResponseBody
+    @ExceptionHandler(RsvpStateNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    String rsvpStateNotFoundHandler(RsvpStateNotFoundException ex) {
+        return ex.getMessage();
+    }
+}

--- a/src/main/java/org/codeseoul/event_member_management/rsvp_state/RsvpStateNotFoundException.java
+++ b/src/main/java/org/codeseoul/event_member_management/rsvp_state/RsvpStateNotFoundException.java
@@ -1,0 +1,7 @@
+package org.codeseoul.event_member_management.rsvp_state;
+
+public class RsvpStateNotFoundException extends RuntimeException {
+    public RsvpStateNotFoundException(Long id) {
+        super("Could not find rsvp state" + id);
+    }
+}

--- a/src/main/java/org/codeseoul/event_member_management/series/Series.java
+++ b/src/main/java/org/codeseoul/event_member_management/series/Series.java
@@ -3,12 +3,10 @@ package org.codeseoul.event_member_management.series;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.codeseoul.event_member_management.common.Auditable;
 import org.codeseoul.event_member_management.event.Event;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
 
 import javax.persistence.*;
-import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -16,21 +14,13 @@ import java.util.Objects;
 @Entity
 @NoArgsConstructor
 @Data
-public class Series {
+public class Series extends Auditable {
     private @Id @GeneratedValue Long id;
     private String name;
 
     @OneToMany(mappedBy = "series", fetch = FetchType.LAZY)
     @JsonManagedReference
     private List<Event> events = new ArrayList<>();
-
-    @Column(insertable = false, updatable = false)
-    @CreationTimestamp
-    private Timestamp createdAt;
-
-    @Column(insertable = false, updatable = false)
-    @UpdateTimestamp
-    private Timestamp updatedAt;
 
     public Series(String name) {
         this.name = name;

--- a/src/main/java/org/codeseoul/event_member_management/sns_account/SnsAccount.java
+++ b/src/main/java/org/codeseoul/event_member_management/sns_account/SnsAccount.java
@@ -2,15 +2,12 @@ package org.codeseoul.event_member_management.sns_account;
 
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.codeseoul.event_member_management.common.Auditable;
 import org.codeseoul.event_member_management.member.Member;
-import org.codeseoul.event_member_management.series.Series;
 import org.codeseoul.event_member_management.sns_service.SnsService;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
-import java.sql.Timestamp;
 import java.util.Objects;
 
 @Entity
@@ -18,10 +15,10 @@ import java.util.Objects;
 @Data
 @Table(
     uniqueConstraints = @UniqueConstraint(
-        columnNames = {"externalId", "sns_service_id"}
+        columnNames = {"external_id", "sns_service_id"}
     )
 )
-public class SnsAccount {
+public class SnsAccount extends Auditable {
     private @Id @GeneratedValue Long id;
 
     @NotNull
@@ -36,14 +33,6 @@ public class SnsAccount {
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "sns_service_id")
     private SnsService snsService;
-
-    @Column(insertable = false, updatable = false)
-    @CreationTimestamp
-    private Timestamp createdAt;
-
-    @Column(insertable = false, updatable = false)
-    @UpdateTimestamp
-    private Timestamp updatedAt;
 
     public SnsAccount(Member member, String externalId, SnsService snsService) {
         this.member = member;

--- a/src/main/java/org/codeseoul/event_member_management/sns_service/SnsService.java
+++ b/src/main/java/org/codeseoul/event_member_management/sns_service/SnsService.java
@@ -2,11 +2,11 @@ package org.codeseoul.event_member_management.sns_service;
 
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
 
-import javax.persistence.*;
-import java.sql.Timestamp;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
 import java.util.Objects;
 
 @Entity
@@ -19,14 +19,6 @@ public class SnsService {
     private String name;
 
     private String iconUrl;
-
-    @Column(insertable = false, updatable = false)
-    @CreationTimestamp
-    private Timestamp createdAt;
-
-    @Column(insertable = false, updatable = false)
-    @UpdateTimestamp
-    private Timestamp updatedAt;
 
     public SnsService(String name, String iconUrl) {
         this.name = name;


### PR DESCRIPTION
Now tracks RSVP states separately.
Set up various models to be "auditable", that is, to have createdAt and updatedAt timestamps.
Fixed up RSVP endpoints to produce more useful output.
I'm bad at making atomic commits, but that's only because no one else is working on this right now.