### PR TITLE
Changed JDK image to support ARM arquitectures

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -84,5 +84,6 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64/v8
           push: true
           tags: ghcr.io/codeseoul/event_member_management_backend:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-alpine
+FROM eclipse-temurin:17-jdk
 
 EXPOSE 8080
 


### PR DESCRIPTION
### Purpose of Changes

The current Docker image only supports x86 architecture thus developers with Apple Silicon computers can't run the image.

### Description of Changes

Changed from Alpine Linux image to generic JDK 17 image.

### Checklist
- [ ] My changes have [automated tests](https://docs.spring.io/spring-framework/docs/current/reference/html/testing.html)
- [X] I tested my changes interactively
- [ ] I included [docstrings](https://docs.oracle.com/en/java/javase/17/docs/specs/javadoc/doc-comment-spec.html)
- [X] My changes can't reasonably be split into smaller PRs
